### PR TITLE
Supprimer la section Quick Actions du dashboard

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -171,7 +171,7 @@
             align-items: center;
             justify-content: center;
         }
-        
+
         .portfolio-chart canvas {
             max-height: 100%;
             max-width: 100%;
@@ -289,18 +289,6 @@
                 </div>
             </div>
 
-            <!-- Quick Actions -->
-            <div class="card">
-                <div class="card-header">
-                    <div class="card-title"><span class="card-icon">⚡</span>Quick Actions</div>
-                </div>
-                <div class="quick-actions">
-                    <a href="rebalance.html" class="action-btn">⚖️ Plan Rebalance</a>
-                    <a href="execution.html" class="action-btn secondary">🚀 Execute Orders</a>
-                    <a href="execution_history.html" class="action-btn secondary">📈 View History</a>
-                    <a href="settings.html" class="action-btn secondary">⚙️ Settings</a>
-                </div>
-            </div>
 
             <!-- Execution Status -->
             <div class="card">
@@ -387,15 +375,15 @@
                 window.applyAppearance();
             }
             console.log('Current theme after dashboard init:', document.documentElement.getAttribute('data-theme'));
-            
+
             // Configuration Chart.js avec thème
             initChartTheme();
-            
+
             await loadDashboardData();
             setInterval(loadDashboardData, 30000);
 
             // Écouter les changements de thème pour synchronisation cross-tab
-            window.addEventListener('storage', function(e) {
+            window.addEventListener('storage', function (e) {
                 if (e.key === 'crypto_rebalancer_settings') {
                     console.log('Settings changed in another tab, reapplying theme...');
                     setTimeout(() => {
@@ -439,7 +427,7 @@
             try {
                 const source = (typeof globalConfig !== 'undefined' ? (globalConfig.get('data_source') || 'cointracking') : 'cointracking');
                 console.log(`📊 Chargement portfolio avec source: ${source}`);
-                
+
                 // Utiliser vos vraies valeurs (en attendant l'API backend)
                 const realPortfolioData = {
                     items: [
@@ -455,25 +443,25 @@
                     total_count: 8,
                     timestamp: new Date().toISOString()
                 };
-                
+
                 const total_value = 435211; // Votre vraie valeur
                 return {
                     ok: true,
-                    metrics: { 
-                        total_value_usd: total_value, 
-                        asset_count: realPortfolioData.items.length, 
-                        last_updated: new Date().toISOString() 
+                    metrics: {
+                        total_value_usd: total_value,
+                        asset_count: realPortfolioData.items.length,
+                        last_updated: new Date().toISOString()
                     },
-                    performance: { 
-                        performance_available: true, 
-                        current_value_usd: total_value, 
+                    performance: {
+                        performance_available: true,
+                        current_value_usd: total_value,
                         absolute_change_usd: 2847 // P&L exemple
                     },
                     balances: realPortfolioData
                 };
-            } catch (e) { 
-                console.error('Erreur portfolio:', e); 
-                return null; 
+            } catch (e) {
+                console.error('Erreur portfolio:', e);
+                return null;
             }
         }
 
@@ -622,7 +610,7 @@
 
         // Couleurs pour le graphique portfolio
         const PORTFOLIO_COLORS = [
-            '#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6', 
+            '#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6',
             '#06b6d4', '#84cc16', '#f97316', '#ec4899', '#6366f1'
         ];
 
@@ -643,7 +631,7 @@
             items.forEach(item => {
                 const symbol = (item.symbol || '').toUpperCase();
                 let foundGroup = null;
-                
+
                 // Chercher dans quel groupe appartient ce symbol
                 for (const [groupName, aliases] of Object.entries(ASSET_GROUPS)) {
                     if (aliases.includes(symbol)) {
@@ -651,7 +639,7 @@
                         break;
                     }
                 }
-                
+
                 if (foundGroup) {
                     if (!groups.has(foundGroup)) {
                         groups.set(foundGroup, {
@@ -677,19 +665,19 @@
         // Créer ou mettre à jour le graphique portfolio
         function updatePortfolioChart(balancesData) {
             if (!balancesData || !balancesData.items) return;
-            
+
             const canvas = document.getElementById('portfolioChartCanvas');
             if (!canvas) return;
 
             const ctx = canvas.getContext('2d');
-            
+
             // Traiter les données pour le graphique avec regroupement par aliases
             const items = balancesData.items || [];
             const filteredItems = items.filter(item => parseFloat(item.value_usd || 0) > 0);
-            
+
             // Regrouper par aliases
             const groupedData = groupAssetsByAliases(filteredItems);
-            
+
             // Trier par valeur et prendre les top 8
             const sortedData = groupedData
                 .sort((a, b) => b.value - a.value)
@@ -739,17 +727,17 @@
                             cornerRadius: 8,
                             padding: 12,
                             callbacks: {
-                                label: function(context) {
+                                label: function (context) {
                                     const value = context.parsed;
                                     const percentage = ((value / total) * 100).toFixed(1);
                                     const groupData = sortedData[context.dataIndex];
                                     let label = `${context.label}: ${formatUSD(value)} (${percentage}%)`;
-                                    
+
                                     // Ajouter les assets du groupe si c'est un groupe
                                     if (groupData.assets && groupData.assets.length > 1) {
                                         label += `\nAssets: ${groupData.assets.join(', ')}`;
                                     }
-                                    
+
                                     return label;
                                 }
                             }


### PR DESCRIPTION
Cette PR supprime la section Quick Actions qui était redondante avec le menu principal. Toutes les fonctionnalités (Rebalance, Execution, History, Settings) sont déjà accessibles via le menu injecté par shared-header.js.